### PR TITLE
🔒 Fix unbounded string split in default Parse (v2)

### DIFF
--- a/src/CalendarVersioning/CalendarVersion.cs
+++ b/src/CalendarVersioning/CalendarVersion.cs
@@ -30,13 +30,17 @@ namespace CalendarVersioning
             if (string.IsNullOrWhiteSpace(input))
                 throw new ArgumentException("Input cannot be null or empty", nameof(input));
 
+            if (input.Length > 256)
+                throw new ArgumentException("Input version string is too long", nameof(input));
 
             int year = 0, month = 0;
             int? day = null, minor = null;
 
-            var parts = input.Split('.');
+            string[] parts;
             if (format == null)
             {
+                parts = input.Split('.', 5);
+
                 // Default parsing: YYYY.MM[.DD[.Minor]]
                 if (parts.Length is < 2 or > 4)
                     throw new FormatException($"Version string '{input}' does not match default format 'YYYY.MM[.DD[.Minor]]'");
@@ -51,7 +55,9 @@ namespace CalendarVersioning
 
             // Parsing using the format
             string pattern = format.Pattern;
-            var tokens = pattern.Split('.');
+            var tokens = pattern.Split('.', 10);
+            parts = input.Split('.', tokens.Length + 1);
+
             if (tokens.Length != parts.Length)
                 throw new FormatException($"Version string '{input}' does not match format '{pattern}'");
 

--- a/tests/CalendarVersioning.Tests/UnitTests/ParsingTests.cs
+++ b/tests/CalendarVersioning.Tests/UnitTests/ParsingTests.cs
@@ -103,5 +103,27 @@ namespace CalendarVersioning.Tests.UnitTests
             var format = new CalendarVersionFormat("YY.MM");
             Assert.Throws<FormatException>(() => CalendarVersion.Parse("123.04", format));
         }
+
+        [Fact]
+        public void Parse_TooLongInput_ShouldThrowArgumentException()
+        {
+            string longInput = new string('a', 257);
+            Assert.Throws<ArgumentException>(() => CalendarVersion.Parse(longInput));
+        }
+
+        [Fact]
+        public void Parse_TooManyDots_ShouldThrowFormatException()
+        {
+            string inputWithManyDots = "2025.04.01.1.extra.dots"; // 6 parts
+            Assert.Throws<FormatException>(() => CalendarVersion.Parse(inputWithManyDots));
+        }
+
+        [Fact]
+        public void Parse_CustomFormat_TooManyDots_ShouldThrowFormatException()
+        {
+            var format = new CalendarVersionFormat("YYYY.MM");
+            string inputWithManyDots = "2025.04.01"; // 3 parts for 2 tokens
+            Assert.Throws<FormatException>(() => CalendarVersion.Parse(inputWithManyDots, format));
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability where `CalendarVersion.Parse` used an unbounded `string.Split` on user-provided input.

⚠️ **Risk:** An attacker could provide a very long string with many dots (e.g., millions of dots), causing the `Split` method to allocate a massive array and many small strings, leading to a Denial of Service (DoS) due to excessive memory consumption and CPU usage.

🛡️ **Solution:** 
- Implemented a maximum length check (256 characters) for the input version string.
- Limited the `Split` operation to a maximum number of parts (5 for default format, or `tokenCount + 1` for custom formats).
- Declared the `parts` variable once to avoid CS0136 errors.
- Added unit tests to verify that excessively long strings or strings with too many components are rejected with appropriate exceptions.

---
*PR created automatically by Jules for task [1080110722513811361](https://jules.google.com/task/1080110722513811361) started by @tetri*