### PR TITLE
🧪 [testing improvement] add tests for CalendarVersionFormat constructor and format method

### DIFF
--- a/src/CalendarVersioning/CalendarVersion.cs
+++ b/src/CalendarVersioning/CalendarVersion.cs
@@ -74,15 +74,15 @@ namespace CalendarVersioning
             // Parsing using the format
             string pattern = format.Pattern;
             var tokens = pattern.Split('.', 10);
-            var parts = input.Split('.', tokens.Length + 1);
+            var formatParts = input.Split('.', tokens.Length + 1);
 
-            if (tokens.Length != parts.Length)
+            if (tokens.Length != formatParts.Length)
                 throw new FormatException($"Version string '{input}' does not match format '{pattern}'");
 
             for (int i = 0; i < tokens.Length; i++)
             {
                 var token = tokens[i];
-                var value = int.Parse(parts[i]);
+                var value = int.Parse(formatParts[i]);
 
                 switch (token)
                 {
@@ -91,7 +91,7 @@ namespace CalendarVersioning
                         break;
                     case "YY":
                         if (value is < 0 or > 99)
-                            throw new FormatException($"Invalid YY value '{parts[i]}' in version string '{input}'");
+                            throw new FormatException($"Invalid YY value '{formatParts[i]}' in version string '{input}'");
                         year = 2000 + value;
                         break;
                     case "MM":

--- a/tests/CalendarVersioning.Tests/UnitTests/CalendarVersionFormatTests.cs
+++ b/tests/CalendarVersioning.Tests/UnitTests/CalendarVersionFormatTests.cs
@@ -1,0 +1,62 @@
+using System;
+using Xunit;
+using CalendarVersioning;
+
+namespace CalendarVersioning.Tests.UnitTests
+{
+    public class CalendarVersionFormatTests
+    {
+        [Fact]
+        public void Constructor_WithPattern_SetsPatternProperty()
+        {
+            // Arrange
+            var pattern = "YYYY.MM.DD";
+
+            // Act
+            var format = new CalendarVersionFormat(pattern);
+
+            // Assert
+            Assert.Equal(pattern, format.Pattern);
+        }
+
+        [Theory]
+        [InlineData("YYYY.MM", 2025, 4, null, null, "2025.04")]
+        [InlineData("YY.MM.DD", 2025, 4, 29, null, "25.04.29")]
+        [InlineData("YYYY.MM.DD.Minor", 2025, 4, 29, 1, "2025.04.29.1")]
+        [InlineData("YYYY-MM-DD", 2025, 4, 29, null, "2025-04-29")]
+        public void Format_WithValidPatterns_ReturnsExpectedStrings(string pattern, int year, int month, int? day, int? minor, string expected)
+        {
+            // Arrange
+            var format = new CalendarVersionFormat(pattern);
+            var version = new CalendarVersion(year, month, day, minor, format);
+
+            // Act
+            var result = format.Format(version);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Format_MissingDay_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var format = new CalendarVersionFormat("YYYY.MM.DD");
+            var version = new CalendarVersion(2025, 4, day: null, minor: null, format: format);
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => format.Format(version));
+        }
+
+        [Fact]
+        public void Format_MissingMinor_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var format = new CalendarVersionFormat("YYYY.MM.Minor");
+            var version = new CalendarVersion(2025, 4, day: 29, minor: null, format: format);
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() => format.Format(version));
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing unit tests for the `CalendarVersionFormat` class, specifically its constructor and the `Format` method.

📊 **Coverage:** What scenarios are now tested
- Constructor correctly assigns the pattern string to the `Pattern` property.
- `Format` method correctly formats `CalendarVersion` objects for patterns like "YYYY.MM", "YY.MM.DD", "YYYY.MM.DD.Minor", and even custom separators like "YYYY-MM-DD".
- `Format` method correctly throws `InvalidOperationException` when the pattern requires a `Day` or `Minor` version component that is not provided in the `CalendarVersion` object.

✨ **Result:** The improvement in test coverage
The addition of `CalendarVersionFormatTests.cs` ensures that custom formatting logic is reliable and handles edge cases appropriately, improving the overall stability of the CalendarVersioning library.

---
*PR created automatically by Jules for task [2374914600003663477](https://jules.google.com/task/2374914600003663477) started by @tetri*