### PR TITLE
🔒 [security fix] Handle OverflowException in CalendarVersion.TryParse

### DIFF
--- a/src/CalendarVersioning/CalendarVersion.cs
+++ b/src/CalendarVersioning/CalendarVersion.cs
@@ -135,6 +135,10 @@ namespace CalendarVersioning
             {
                 return false;
             }
+            catch (OverflowException)
+            {
+                return false;
+            }
         }
 
         public override string ToString()

--- a/tests/CalendarVersioning.Tests/UnitTests/SecurityVulnerabilityReproductionTests.cs
+++ b/tests/CalendarVersioning.Tests/UnitTests/SecurityVulnerabilityReproductionTests.cs
@@ -1,0 +1,27 @@
+using Xunit;
+using CalendarVersioning;
+
+namespace CalendarVersioning.Tests.UnitTests
+{
+    public class SecurityVulnerabilityReproductionTests
+    {
+        [Fact]
+        public void TryParse_OverflowInput_ShouldReturnFalseNotThrow()
+        {
+            var overflowInput = "99999999999999999999.01.01";
+            var success = CalendarVersion.TryParse(overflowInput, out var result);
+            Assert.False(success);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void TryParse_WithFormat_OverflowInput_ShouldReturnFalseNotThrow()
+        {
+            var overflowInput = "99999999999999999999.01.01";
+            var format = new CalendarVersionFormat("YYYY.MM.DD");
+            var success = CalendarVersion.TryParse(overflowInput, format, out var result);
+            Assert.False(success);
+            Assert.Null(result);
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** This PR fixes an unhandled `OverflowException` in the `CalendarVersion.TryParse` method.

⚠️ **Risk:** Without this fix, parsing a malformed Calendar Version string with extremely large numeric components (exceeding 32-bit integer limits) would cause an unhandled exception, potentially leading to a Denial of Service (DoS) by crashing the application.

🛡️ **Solution:** I added a `catch (OverflowException)` block to the primary `TryParse` implementation in `CalendarVersion.cs`. This ensures that any numeric overflow during parsing is treated as a failed parse attempt (returning `false`), consistent with how `FormatException` and `ArgumentException` are handled. I also added a new test file `SecurityVulnerabilityReproductionTests.cs` with unit tests that specifically target this scenario.

---
*PR created automatically by Jules for task [17645220529026254655](https://jules.google.com/task/17645220529026254655) started by @tetri*